### PR TITLE
2기 1주 10o0o

### DIFF
--- a/2nd/week1/p-12906_10o0o.js
+++ b/2nd/week1/p-12906_10o0o.js
@@ -1,0 +1,9 @@
+function solution(arr) {
+  const result = [];
+  
+  for (const el of arr) {
+      if (result[result.length - 1] !== el) result.push(el);
+  }
+  
+  return result;
+}

--- a/2nd/week1/p-12909_10o0o.js
+++ b/2nd/week1/p-12909_10o0o.js
@@ -1,0 +1,14 @@
+function solution (s) {
+  let opens = 0;
+  
+  for (let i = 0; i < s.length; i += 1) {
+      const str = s[i];
+      
+      if (str === '(') opens += 1;
+      else opens -= 1;
+      
+      if (opens < 0) return false;
+  }
+  
+  return !opens;
+}

--- a/2nd/week1/p-1845_10o0o.js
+++ b/2nd/week1/p-1845_10o0o.js
@@ -1,0 +1,3 @@
+function solution(nums) {
+  return Math.min(new Set(nums).size, nums.length / 2)
+}

--- a/2nd/week1/p-42576_10o0o.js
+++ b/2nd/week1/p-42576_10o0o.js
@@ -1,0 +1,13 @@
+function solution(participant, completion) {
+  const memo = {};
+  
+  for (const person of completion) {
+      memo[person] = memo[person] !== undefined ? memo[person] + 1 : 1;
+  }
+  
+  for (const person of participant) {
+      if (!memo[person]) return person;
+      
+      memo[person] -= 1;
+  }
+}

--- a/2nd/week1/p-42577_10o0o.js
+++ b/2nd/week1/p-42577_10o0o.js
@@ -1,0 +1,20 @@
+function solution(pb) {
+  pb.sort((a, b) => a.length - b.length);
+  
+  const memo = new Array(20).fill(new Set());
+  
+  for (const phone of pb) {
+      const { length } = phone;
+      
+      for (let i = 0; i < length; i += 1) {
+          const targetMemo = memo[i];
+          const sliced = phone.slice(0, i + 1);
+          
+          if (targetMemo.has(sliced)) return false;
+      }
+      
+      memo[length - 1].add(phone);
+  }
+  
+  return true;
+}

--- a/2nd/week1/p-42578_10o0o.js
+++ b/2nd/week1/p-42578_10o0o.js
@@ -1,0 +1,17 @@
+function solution(clothes) {
+  const memo = new Map();
+  
+  for (const cloth of clothes) {
+      const [name, type] = cloth;
+      
+      if (memo.has(type)) {
+          memo.set(type, [...memo.get(type), name]);
+      } else {
+          memo.set(type, [name]);
+      }
+  }
+  
+  return Array.from(memo.values()).reduce((acc, cur) => {
+      return acc * (cur.length + 1);
+  }, 1) - 1;
+}

--- a/2nd/week1/p-42579_10o0o.js
+++ b/2nd/week1/p-42579_10o0o.js
@@ -1,0 +1,28 @@
+function solution(genres, plays) {
+  const totalCountsMap = {};
+  const genreSongMap = {};
+
+  for (let i = 0; i < genres.length; i += 1) {
+    if (!totalCountsMap[genres[i]]) {
+      totalCountsMap[genres[i]] = plays[i];
+      genreSongMap[genres[i]] = [{
+        id: i,
+        play: plays[i],
+      }];
+    } else {
+      totalCountsMap[genres[i]] += plays[i];
+      genreSongMap[genres[i]].push({
+        id: i,
+        play: plays[i],
+      });
+    }
+  }
+
+  for (const genre in genreSongMap) {
+    genreSongMap[genre] = genreSongMap[genre].sort((a, b) => b.play - a.play).slice(0, 2);
+  }
+
+  return [...new Set(genres)]
+    .sort((a, b) => totalCountsMap[b] - totalCountsMap[a])
+    .flatMap((genre) => genreSongMap[genre].map((el) => el.id));
+}

--- a/2nd/week1/p-42583_10o0o.js
+++ b/2nd/week1/p-42583_10o0o.js
@@ -1,0 +1,82 @@
+class LinkedNode {
+  constructor(value) {
+    this.value = value;
+    this.next = null;
+  }
+}
+
+class Deque {
+  constructor() {
+    this.head = null;
+    this.tail = null;
+    this.length = 0;
+  }
+
+  shift() {
+    if (!this.length) return undefined;
+
+    const { value } = this.head;
+    this.head = this.head.next;
+    this.length -= 1;
+
+    if (!this.length) {
+      this.tail = null;
+    }
+
+    return value;
+  }
+
+  push(value) {
+    const linkedNode = new LinkedNode(value);
+
+    if (!this.length) {
+      this.head = linkedNode;
+    } else {
+      this.tail.next = linkedNode;
+    }
+
+    this.length += 1;
+    this.tail = linkedNode;
+  }
+}
+
+function solution(bridgeLength, weight, truckWeights) {
+  truckWeights.reverse();
+
+  const memo = new Array(truckWeights.length).fill(0);
+  const queue = new Deque();
+
+  let time = 1;
+  let sum = 0;
+
+  while (truckWeights.length) {
+    const lastIndex = truckWeights.length - 1;
+
+    if (truckWeights[lastIndex] + sum <= weight) {
+      memo[lastIndex] = time;
+      sum += truckWeights[lastIndex];
+      queue.push({
+        index: lastIndex,
+        truckWeight: truckWeights.pop(),
+      });
+
+      time += 1;
+    } else {
+      const { index, truckWeight } = queue.shift();
+      const targetTime = memo[index];
+
+      time += Math.max(0, bridgeLength - (time - targetTime));
+      sum -= truckWeight;
+    }
+  }
+
+  while (queue.length) {
+    const { index, truckWeight } = queue.shift();
+    const targetTime = memo[index];
+
+    time += Math.max(0, bridgeLength - (time - targetTime));
+    sum -= truckWeight;
+  }
+
+  return time;
+}

--- a/2nd/week1/p-42584_10o0o.js
+++ b/2nd/week1/p-42584_10o0o.js
@@ -1,0 +1,24 @@
+function solution(prices) {
+  const result = new Array(prices.length);
+  const queue = [];
+
+  for (let i = 0; i < prices.length; i += 1) {
+    while (queue[queue.length - 1] && queue[queue.length - 1].price > prices[i]) {
+      result[queue[queue.length - 1].index] = i - queue[queue.length - 1].index;
+      queue.pop();
+    }
+
+    queue.push({
+      price: prices[i],
+      index: i,
+    });
+  }
+    
+  while (queue.length) {
+    const { index } = queue.pop();
+
+    result[index] = prices.length - 1 - index;
+  }
+
+  return result;
+}

--- a/2nd/week1/p-42586_10o0o.js
+++ b/2nd/week1/p-42586_10o0o.js
@@ -1,0 +1,21 @@
+function solution(progresses, speeds) {
+  const converted = progresses.map((progress, index) => Math.ceil((100 - progress) / speeds[index]));
+  const result = [];
+  
+  let cur = -1;
+  let count = 0;
+  
+  for (const el of converted) {
+      if (el > cur) {
+          result.push(count);
+          count = 1;
+          cur = el;
+      } else {
+          count += 1
+      }
+  }
+  
+  if (count) result.push(count);
+  
+  return result.slice(1);
+}

--- a/2nd/week1/p-42587_10o0o.js
+++ b/2nd/week1/p-42587_10o0o.js
@@ -1,0 +1,43 @@
+class LinkedNode {
+  constructor(priority, location) {
+      this.priority = priority;
+      this.location = location;
+      this.next = null;
+      this.prev = null;
+  }
+}
+
+function solution(priorities, location) {
+  const queue = [...priorities].sort((a, b) => a - b);    
+  const firstNode = new LinkedNode(priorities[0], 0)
+  let head = firstNode;
+  
+  for (let i = 1; i < priorities.length; i += 1) {
+      const linkedNode = new LinkedNode(priorities[i], i);
+      head.next = linkedNode;
+      linkedNode.prev = head;
+      head = linkedNode;
+  }
+  
+  head.next = firstNode;
+  firstNode.prev = head;
+  head = firstNode;
+  
+  let result = 1;
+  
+  while (1) {
+      if (head.priority === queue[queue.length - 1]) {
+          if (head.location === location) {
+              return result;
+          }
+          
+          queue.pop();
+          head.prev.next = head.next;
+          head.next.prev = head.prev;
+          head = head.prev;
+          result += 1;
+      }
+      
+      head = head.next;
+  }
+}


### PR DESCRIPTION
1845 프로그래머스
폰켓몬

- 종류의 개수와, 총 갯수의 반을 비교한 후 그 중 작은값을 return한다

42576 프로그래머스
완주하지 못한 선수

- 도착한 사람들을 객채 배열에 동명이인을 고려하여 count를 저장
- 출발한 사람들을 순회하며, 도착한 사람들에서 count를 빼며 만약 남은 count가 없다면 도착하지 못했으므로 그 사람을 return

42577 프로그래머스
전화번호 목록

- 폰 번호들을 길이순 오름차순으로 정렬
- 번호가 가질 수 있는 최대 길이만큼의 dp배열(memo) 선언
- 순회하면서 brute force로 접두어가 될 수 있는 모든 경우의 수에 대해, 해당 길이만큼의 배열에 담긴 Set 객체에 접두어가 존재하는지 유무 체크
- 존재한다면, return false 없다면 Set객체에 새로운 접두어 add

42578 프로그래머스
의상

- 의상의 종류를 Key로 가지는 Map 객체 생성 후, 종류별로 집합
- 의상의 경우의 수를 고르는 경우는 종류(n1, n2, ... k) 이라고 하면 다음과 같다.

(n + 1) * (n2 + 1) * ... (k + 1)

- 모든 경우의 수 중, 아무것도 고르지 않는 경우의 수 하나를 뺀 후 return


42579 프로그래머스
장르

- 장르의 노래 총 개수를 저장할 객체와 장르의 곡을 저장할 객체 생성
- 장르를 순회하며 객체 업데이트
- 장르의 곡을 저장한 객체를 순회하여, 가장 많이 플레이 된 순 정렬 후, 2개로 slice
- 모든 장르에 대해서 totalCount 내림차순 정렬 후 노래의 id를 return

12906 프로그래머스
같은 숫자는 싫어

- 숫자를 담을 배열 선언 후, 숫자들을 순회하여 배열의 맨 마지막 원소와 다를 시 push 후 배열 return

42586 프로그래머스
기능 개발

- 주어진 조건을 바탕으로 각 index별 작업을 남은 일수로 convert
- 남은일 수 배열을 돌면서, 현재일을 업데이트하며, 만약 업데이트 될 일이 현재일보다 낮다면, count를 증가 아니라면, 여태까지 증가된 count를 result에 push
- result 반환

12909 프로그래머스
올바른 괄호

- string 순회하면서, 괄호가 닫힐 시 여태껏 열린 괄호의 숫자보다 괄호가 닫힌게 많다면 false
- 모두 순회 했는데 아직 열려있는 괄호의 수가 남았다면 false
- 아니라면 true

42587 프로그래머스
프로세스

- priorities를 오름차순으로 저장할 queue 배열 선언
- queue를 저장할 2방향 LinkedList 구성
- priorities 순회하며 순회하는 LinkedList 구성
- LinkedList를 계속 순회하며 queue배열의 가장 큰 요소와 같은 priority를 가진 요소를 만난다면 다음을 체크
  - 만약 요소의 location이 문제에서 찾고자 하는 위치와 같다면 return
  - 아니라면 result(index) +=1 업데이트 및 LinkedList에서 요소 삭제 및 Queue에서 요소 삭제

42583 프로그래머스
다리를 지나는 트럭

- shift를 O(1)로 처리하기 위해 Deque 생성
- 각 트럭이 다리에 진입하는 시간을 기록할 memo 배열 생성
- 트럭을 순회하며 다리에 진입 가능한지 여부 체크
  - 진입이 가능하다면, 진입한 트럭의 총 무게에 현재 트럭의 무게를 더하고, memo에 트럭이 들어간 시간을 체크 후 queue에 트럭을 넣는다
  - 진입이 불가능하다면, queue에 진입한 트럭 중 가장 오래된 트럭을 pop한 후, 트럭이 만약 지났다면 남은 시간을 유지하고, 지나지 못했다면 지나기까지 남은 시간만큼 현재 시간을 더한 후, 트럭의 전체 무게에서 지난 트럭의 무게 감소

42584 프로그래머스
주식 가격

- queue에 주식 가격과 위치 index를 저장
- 주식 가격을 순회하며, queue의 마지막 요소에 있는 주식 가격이 현재 순회중인 주식 가격보다 높은 경우, queue에서 해당 주식 가격 제거한 후, 가격이 떨어진 시점과 주식이 들어간 시점을 비교해서 result 업데이트